### PR TITLE
Add leaderboards.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 cython_debug/
 
 data.json
+leaderboards.txt


### PR DESCRIPTION
The players statistics don't need to be checked into source control.